### PR TITLE
Log directory path from absolute to relative

### DIFF
--- a/Application/MoonApns/NLog.config
+++ b/Application/MoonApns/NLog.config
@@ -5,7 +5,7 @@
   <!-- go to http://nlog-project.org/wiki/Configuration_file for more information -->
 
   <targets>
-    <target name="logfile" xsi:type="File" fileName="D:\MoonAPNS\MoonAPNS\MoonAPNS\Logs\Push Notification\${date:format=yyyyMMdd}.log" archiveEvery="Day" layout="${date:format=yyyyMMdd HHmm} - ${level} - ${message}" createDirs="true"/>
+    <target name="logfile" xsi:type="File" fileName="..\..\..\Logs\Push Notification\${date:format=yyyyMMdd}.log" archiveEvery="Day" layout="${date:format=yyyyMMdd HHmm} - ${level} - ${message}" createDirs="true"/>
   </targets>
 
   <rules>

--- a/Application/MoonApns/PushNotification.cs
+++ b/Application/MoonApns/PushNotification.cs
@@ -74,7 +74,7 @@ namespace MoonAPNS
       }
 
       //Load Certificates in to collection.
-      _certificate = string.IsNullOrEmpty(p12FilePassword)? new X509Certificate2(File.ReadAllBytes(p12File)): new X509Certificate2(File.ReadAllBytes(p12File), p12FilePassword);
+      _certificate = string.IsNullOrEmpty(p12FilePassword)? new X509Certificate2(File.ReadAllBytes(p12File)): new X509Certificate2(File.ReadAllBytes(p12File), p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
       _certificates = new X509CertificateCollection {_certificate};
       
       // Loading Apple error response list.


### PR DESCRIPTION
Changed logging directory on NLog.config from absolute path to relative. And fixed some typos on logging sentences.
